### PR TITLE
Fits read write

### DIFF
--- a/src/Table/write_fits.cxx
+++ b/src/Table/write_fits.cxx
@@ -122,8 +122,9 @@ void tablator::Table::write_fits (fitsfile *fits_file) const
           break;
         case Data_Type::INT64_LE:
         case Data_Type::UINT64_LE:
-          /// Fits does not know what an unsigned long is.  So we write it
-          /// as a long and hope for the best.
+          /// Fits does not know what an unsigned long is.  We write
+          /// both it and signed long as longlong [sic] and hope for
+          /// the best.
           fits_type = 'K';
           break;
         case Data_Type::FLOAT32_LE:
@@ -229,8 +230,9 @@ void tablator::Table::write_fits (fitsfile *fits_file) const
               break;
             case Data_Type::INT64_LE:
             case Data_Type::UINT64_LE:
-              /// Fits does not know what an unsigned long is.  So we write it
-              /// as a long and hope for the best.
+              /// Fits does not know what an unsigned long is.  We write
+              /// both it and signed long as longlong [sic] and hope for
+              /// the best.
               write_column<int64_t>(fits_file, TLONGLONG, i, offset_data,
                                     columns[i].array_size, row);
               break;

--- a/test/back_and_forth_tables/non_char_arrays.json5
+++ b/test/back_and_forth_tables/non_char_arrays.json5
@@ -1,0 +1,73 @@
+{
+    "VOTABLE":
+    {
+        "<xmlattr>":
+        {
+            "version": "1.3",
+            "xmlns:xsi": "http:\/\/www.w3.org\/2001\/XMLSchema-instance",
+            "xmlns": "http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3",
+            "xmlns:stc": "http:\/\/www.ivoa.net\/xml\/STC\/v1.30",
+            "xsi:schemaLocation": "http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3 http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3 http:\/\/www.ivoa.net\/xml\/STC\/v1.30 http:\/\/www.ivoa.net\/xml\/STC\/v1.30"
+        },
+        "RESOURCE":
+        {
+            "TABLE":
+            {
+                "FIELD":
+                {
+                    "<xmlattr>":
+                    {
+                        "name": "bools",
+                        "datatype": "boolean",
+                        "arraysize": "*"
+                    }
+                },
+                "FIELD":
+                {
+                    "<xmlattr>":
+                    {
+                        "name": "ints",
+                        "datatype": "int",
+                        "arraysize": "*"
+                    }
+                },
+                "FIELD":
+                {
+                    "<xmlattr>":
+                    {
+                        "name": "uints",
+                        "datatype": "uint",
+                        "arraysize": "*"
+                    }
+                },
+                "FIELD":
+                {
+                    "<xmlattr>":
+                    {
+                        "name": "longs",
+                        "datatype": "long",
+                        "arraysize": "*"
+                    }
+                },
+                "DATA":
+                {
+                    "TABLEDATA":
+                    [
+                        [
+                            "1 1 0 1 0 1 0 1 1 1 0 1 1 0 1 1 1 0 1",
+                            "16383 -16383 4986 -4986 255 72",
+                            "65535 16384 1022 47 11 1234 5678 0 2",
+                            "65535 16384 1022 47 11 1234 5678 0 2 0 23456"
+                        ],
+                        [
+                            "0 1 1 0 1 0 1 0 1 1 1 0 1 1 0 1 1 1 0",
+                            "10000 1000 100 -10000 -1000 -100",
+                            "3 4 567 8901 12345 6789 9876 0 0",
+                            "3 4 567 8901 12345 6789 9876 0 0 65535 0"
+                        ]
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/test/back_and_forth_tables/one_row_bool_array.json5
+++ b/test/back_and_forth_tables/one_row_bool_array.json5
@@ -1,0 +1,37 @@
+{
+    "VOTABLE":
+    {
+        "<xmlattr>":
+        {
+            "version": "1.3",
+            "xmlns:xsi": "http:\/\/www.w3.org\/2001\/XMLSchema-instance",
+            "xmlns": "http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3",
+            "xmlns:stc": "http:\/\/www.ivoa.net\/xml\/STC\/v1.30",
+            "xsi:schemaLocation": "http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3 http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3 http:\/\/www.ivoa.net\/xml\/STC\/v1.30 http:\/\/www.ivoa.net\/xml\/STC\/v1.30"
+        },
+        "RESOURCE":
+        {
+            "TABLE":
+            {
+                "FIELD":
+                {
+                    "<xmlattr>":
+                    {
+                        "name": "bools",
+                        "datatype": "boolean",
+                        "arraysize": "*"
+                    }
+                },
+                "DATA":
+                {
+                    "TABLEDATA":
+                    [
+                        [
+                            "1 1 0 1 0 1 0 1 1 1 0 1 1 0 1 1 1 0 1"
+                        ]
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/test/back_and_forth_tables/one_row_int_array.json5
+++ b/test/back_and_forth_tables/one_row_int_array.json5
@@ -1,0 +1,37 @@
+{
+    "VOTABLE":
+    {
+        "<xmlattr>":
+        {
+            "version": "1.3",
+            "xmlns:xsi": "http:\/\/www.w3.org\/2001\/XMLSchema-instance",
+            "xmlns": "http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3",
+            "xmlns:stc": "http:\/\/www.ivoa.net\/xml\/STC\/v1.30",
+            "xsi:schemaLocation": "http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3 http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3 http:\/\/www.ivoa.net\/xml\/STC\/v1.30 http:\/\/www.ivoa.net\/xml\/STC\/v1.30"
+        },
+        "RESOURCE":
+        {
+            "TABLE":
+            {
+                "FIELD":
+                {
+                    "<xmlattr>":
+                    {
+                        "name": "ints",
+                        "datatype": "int",
+                        "arraysize": "*"
+                    }
+                },
+                "DATA":
+                {
+                    "TABLEDATA":
+                    [
+                        [
+                            "1 2 3 4"
+                        ]
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/test/back_and_forth_tables/one_row_uint_array.json5
+++ b/test/back_and_forth_tables/one_row_uint_array.json5
@@ -1,0 +1,37 @@
+{
+    "VOTABLE":
+    {
+        "<xmlattr>":
+        {
+            "version": "1.3",
+            "xmlns:xsi": "http:\/\/www.w3.org\/2001\/XMLSchema-instance",
+            "xmlns": "http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3",
+            "xmlns:stc": "http:\/\/www.ivoa.net\/xml\/STC\/v1.30",
+            "xsi:schemaLocation": "http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3 http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3 http:\/\/www.ivoa.net\/xml\/STC\/v1.30 http:\/\/www.ivoa.net\/xml\/STC\/v1.30"
+        },
+        "RESOURCE":
+        {
+            "TABLE":
+            {
+                "FIELD":
+                {
+                    "<xmlattr>":
+                    {
+                        "name": "uints",
+                        "datatype": "uint",
+                        "arraysize": "*"
+                    }
+                },
+                "DATA":
+                {
+                    "TABLEDATA":
+                    [
+                        [
+                            "1 2 3 4"
+                        ]
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/test/back_and_forth_tables/single_bool_col.json5
+++ b/test/back_and_forth_tables/single_bool_col.json5
@@ -1,0 +1,66 @@
+{
+    "VOTABLE":
+    {
+        "<xmlattr>":
+        {
+            "version": "1.3",
+            "xmlns:xsi": "http:\/\/www.w3.org\/2001\/XMLSchema-instance",
+            "xmlns": "http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3",
+            "xmlns:stc": "http:\/\/www.ivoa.net\/xml\/STC\/v1.30",
+            "xsi:schemaLocation": "http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3 http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3 http:\/\/www.ivoa.net\/xml\/STC\/v1.30 http:\/\/www.ivoa.net\/xml\/STC\/v1.30"
+        },
+        "RESOURCE":
+        {
+            "TABLE":
+            {
+                "FIELD":
+                {
+                    "<xmlattr>":
+                    {
+                        "name": "bools",
+                        "datatype": "boolean"
+                    }
+                },
+                "DATA":
+                {
+                    "TABLEDATA":
+                    [
+                        [
+                            "1"
+                        ],
+                        [
+                            "1"
+                        ],
+                        [
+                            "0"
+                        ],
+                        [
+                            "0"
+                        ],
+                        [
+                            "1"
+                        ],
+                        [
+                            "1"
+                        ],
+                        [
+                            "0"
+                        ],
+                        [
+                            "1"
+                        ],
+                        [
+                            "1"
+                        ],
+                        [
+                            "1"
+                        ],
+                        [
+                            "0"
+                        ]
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/test/back_and_forth_tables/two_row_bool_array.json5
+++ b/test/back_and_forth_tables/two_row_bool_array.json5
@@ -1,0 +1,40 @@
+{
+    "VOTABLE":
+    {
+        "<xmlattr>":
+        {
+            "version": "1.3",
+            "xmlns:xsi": "http:\/\/www.w3.org\/2001\/XMLSchema-instance",
+            "xmlns": "http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3",
+            "xmlns:stc": "http:\/\/www.ivoa.net\/xml\/STC\/v1.30",
+            "xsi:schemaLocation": "http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3 http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3 http:\/\/www.ivoa.net\/xml\/STC\/v1.30 http:\/\/www.ivoa.net\/xml\/STC\/v1.30"
+        },
+        "RESOURCE":
+        {
+            "TABLE":
+            {
+                "FIELD":
+                {
+                    "<xmlattr>":
+                    {
+                        "name": "bools",
+                        "datatype": "boolean",
+                        "arraysize": "*"
+                    }
+                },
+                "DATA":
+                {
+                    "TABLEDATA":
+                    [
+                        [
+                            "1 1 0 1 0 1 0 1 1 1 0 1 1 0 1 1 1 0 1"
+                        ],
+                        [
+                            "0 1 1 0 1 0 1 0 1 1 1 0 1 1 0 1 1 1 0"
+                        ]
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/test/back_and_forth_tables/two_row_int_array.json5
+++ b/test/back_and_forth_tables/two_row_int_array.json5
@@ -1,0 +1,40 @@
+{
+    "VOTABLE":
+    {
+        "<xmlattr>":
+        {
+            "version": "1.3",
+            "xmlns:xsi": "http:\/\/www.w3.org\/2001\/XMLSchema-instance",
+            "xmlns": "http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3",
+            "xmlns:stc": "http:\/\/www.ivoa.net\/xml\/STC\/v1.30",
+            "xsi:schemaLocation": "http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3 http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3 http:\/\/www.ivoa.net\/xml\/STC\/v1.30 http:\/\/www.ivoa.net\/xml\/STC\/v1.30"
+        },
+        "RESOURCE":
+        {
+            "TABLE":
+            {
+                "FIELD":
+                {
+                    "<xmlattr>":
+                    {
+                        "name": "ints",
+                        "datatype": "int",
+                        "arraysize": "*"
+                    }
+                },
+                "DATA":
+                {
+                    "TABLEDATA":
+                    [
+                        [
+                            "11111 -22222 12345 -12345"
+                        ],
+                        [
+                            "1111 2222 -3333 -4444"
+                        ]
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/test/back_and_forth_tables/two_row_long_array.json5
+++ b/test/back_and_forth_tables/two_row_long_array.json5
@@ -1,0 +1,40 @@
+{
+    "VOTABLE":
+    {
+        "<xmlattr>":
+        {
+            "version": "1.3",
+            "xmlns:xsi": "http:\/\/www.w3.org\/2001\/XMLSchema-instance",
+            "xmlns": "http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3",
+            "xmlns:stc": "http:\/\/www.ivoa.net\/xml\/STC\/v1.30",
+            "xsi:schemaLocation": "http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3 http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3 http:\/\/www.ivoa.net\/xml\/STC\/v1.30 http:\/\/www.ivoa.net\/xml\/STC\/v1.30"
+        },
+        "RESOURCE":
+        {
+            "TABLE":
+            {
+                "FIELD":
+                {
+                    "<xmlattr>":
+                    {
+                        "name": "longs",
+                        "datatype": "long",
+                        "arraysize": "*"
+                    }
+                },
+                "DATA":
+                {
+                    "TABLEDATA":
+                    [
+                        [
+                            "1 -1 2 -2"
+                        ],
+                        [
+                            "555555555555 123451234512345 -555555555555 -123451234512345"
+                        ]
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/test/back_and_forth_tables/two_row_uint_array.json5
+++ b/test/back_and_forth_tables/two_row_uint_array.json5
@@ -1,0 +1,40 @@
+{
+    "VOTABLE":
+    {
+        "<xmlattr>":
+        {
+            "version": "1.3",
+            "xmlns:xsi": "http:\/\/www.w3.org\/2001\/XMLSchema-instance",
+            "xmlns": "http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3",
+            "xmlns:stc": "http:\/\/www.ivoa.net\/xml\/STC\/v1.30",
+            "xsi:schemaLocation": "http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3 http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3 http:\/\/www.ivoa.net\/xml\/STC\/v1.30 http:\/\/www.ivoa.net\/xml\/STC\/v1.30"
+        },
+        "RESOURCE":
+        {
+            "TABLE":
+            {
+                "FIELD":
+                {
+                    "<xmlattr>":
+                    {
+                        "name": "uints",
+                        "datatype": "uint",
+                        "arraysize": "*"
+                    }
+                },
+                "DATA":
+                {
+                    "TABLEDATA":
+                    [
+                        [
+                            "11111 22222 33333 44444"
+                        ],
+                        [
+                            "1111 2222 3333 4444"
+                        ]
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/test/back_and_forth_tables/two_row_ulong_array.json5
+++ b/test/back_and_forth_tables/two_row_ulong_array.json5
@@ -1,0 +1,40 @@
+{
+    "VOTABLE":
+    {
+        "<xmlattr>":
+        {
+            "version": "1.3",
+            "xmlns:xsi": "http:\/\/www.w3.org\/2001\/XMLSchema-instance",
+            "xmlns": "http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3",
+            "xmlns:stc": "http:\/\/www.ivoa.net\/xml\/STC\/v1.30",
+            "xsi:schemaLocation": "http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3 http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3 http:\/\/www.ivoa.net\/xml\/STC\/v1.30 http:\/\/www.ivoa.net\/xml\/STC\/v1.30"
+        },
+        "RESOURCE":
+        {
+            "TABLE":
+            {
+                "FIELD":
+                {
+                    "<xmlattr>":
+                    {
+                        "name": "ulongs",
+                        "datatype": "ulong",
+                        "arraysize": "*"
+                    }
+                },
+                "DATA":
+                {
+                    "TABLEDATA":
+                    [
+                        [
+                            "1 1 2 2"
+                        ],
+                        [
+                            "555555555555 123451234512345 555555555555 123451234512345"
+                        ]
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/test/back_and_forth_tables/two_row_ulong_array_via_fits.json5
+++ b/test/back_and_forth_tables/two_row_ulong_array_via_fits.json5
@@ -1,0 +1,40 @@
+{
+    "VOTABLE":
+    {
+        "<xmlattr>":
+        {
+            "version": "1.3",
+            "xmlns:xsi": "http:\/\/www.w3.org\/2001\/XMLSchema-instance",
+            "xmlns": "http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3",
+            "xmlns:stc": "http:\/\/www.ivoa.net\/xml\/STC\/v1.30",
+            "xsi:schemaLocation": "http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3 http:\/\/www.ivoa.net\/xml\/VOTable\/v1.3 http:\/\/www.ivoa.net\/xml\/STC\/v1.30 http:\/\/www.ivoa.net\/xml\/STC\/v1.30"
+        },
+        "RESOURCE":
+        {
+            "TABLE":
+            {
+                "FIELD":
+                {
+                    "<xmlattr>":
+                    {
+                        "name": "ulongs",
+                        "datatype": "long",
+                        "arraysize": "*"
+                    }
+                },
+                "DATA":
+                {
+                    "TABLEDATA":
+                    [
+                        [
+                            "1 1 2 2"
+                        ],
+                        [
+                            "555555555555 123451234512345 555555555555 123451234512345"
+                        ]
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/test/convert.sh
+++ b/test/convert.sh
@@ -1,7 +1,48 @@
 #!/bin/bash
 
+#############################################################################
+## helper functions
+#############################################################################
+
+usage()
+{
+    script_name=$1
+    echo "Usage: ${script_name} [-b path_to_tablator_binary]"
+    echo ""
+}
+
+
+# Generate command line to exit the script without exiting the shell,
+# whether source'd or run from screen or otherwise.
+get_out()
+{
+   echo "return $1 2> /dev/null || exit $1"
+}
+
+
+#############################################################################
+## main function
+#############################################################################
+
+tablator_bin="build/tablator"
+
+OPTIND=1
+while getopts ":b:h" opt; do
+    case $opt in
+        b ) tablator_bin=$OPTARG
+            ;;
+        * ) usage $0
+            exit 1
+            eval `get_out 1`
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+
+
 for table in test/bad_ipac_tables/* test/bad_votables/*; do
-    build/tablator $table bad_table.hdf5 2> /dev/null
+    ${tablator_bin} $table bad_table.hdf5 2> /dev/null
     if [ $? -eq 0 ]; then
         echo "FAIL: $table"
     else
@@ -17,14 +58,14 @@ for table in test/multi test/dos_ending.csv test/multi.csv test/multi.tsv test/f
     fi
     for ending in tbl hdf5 xml csv tsv fits html json json5 postgres sqlite oracle db; do
         if [ $ending == "db" ]; then
-            build/tablator $table test.$ending
+            ${tablator_bin} $table test.$ending
         else
-            build/tablator $STREAM_INTERMEDIATE $table test.$ending
+            ${tablator_bin} $STREAM_INTERMEDIATE $table test.$ending
         fi
         if [ $ending == "hdf5" ] || [ $ending == "fits" ]; then
-            build/tablator test.$ending temp.tbl
+            ${tablator_bin} test.$ending temp.tbl
         elif [ $ending == "xml" ] || [ $ending == "json" ] || [ $ending == "tbl" ]; then
-            build/tablator $STREAM_INTERMEDIATE test.$ending temp.tbl
+            ${tablator_bin} $STREAM_INTERMEDIATE test.$ending temp.tbl
         fi
         if [ $? -eq 0 ]; then
             echo "PASS: $table <-> $ending"
@@ -35,8 +76,8 @@ for table in test/multi test/dos_ending.csv test/multi.csv test/multi.tsv test/f
     done
 done
 
-build/tablator --input-format=hdf5 --output-format=ipac_table test/h5_as_csv.csv temp.h5
-build/tablator --input-format=ipac_table temp.h5 temp.tbl
+${tablator_bin} --input-format=hdf5 --output-format=ipac_table test/h5_as_csv.csv temp.h5
+${tablator_bin} --input-format=ipac_table temp.h5 temp.tbl
 if [ $? -eq 0 ]; then
     echo "PASS: Explicit format specified"
 else
@@ -44,7 +85,7 @@ else
 fi
 rm -f temp.tbl temp.h5
 
-build/tablator --output-format=votable test/recursive_param.xml - | diff - test/recursive_param.xml
+${tablator_bin} --output-format=votable test/recursive_param.xml - | diff - test/recursive_param.xml
 
 if [ $? -eq 0 ]; then
     echo "PASS: recursive param tabledata"
@@ -52,86 +93,164 @@ else
     echo "FAIL: recursive param tabledata"
 fi
 
-build/tablator --output-format=votable test/recursive_param_binary2.xml  - | diff - test/recursive_param.xml
+${tablator_bin} --output-format=votable test/recursive_param_binary2.xml  - | diff - test/recursive_param.xml
 if [ $? -eq 0 ]; then
     echo "PASS: recursive param binary2"
 else
     echo "FAIL: recursive param binary2"
 fi
 
-./build/tablator --output-format=csv test/al.csv - | diff -w - test/al.csv
+${tablator_bin} --output-format=csv test/al.csv - | diff -w - test/al.csv
 if [ $? -eq 0 ]; then
     echo "PASS: CSV implicit float"
 else
     echo "FAIL: CSV implicit float"
 fi
 
-./build/tablator --output-format=html test/multi.tbl - | diff -w - test/multi.html
+${tablator_bin} --output-format=html test/multi.tbl - | diff -w - test/multi.html
 if [ $? -eq 0 ]; then
     echo "PASS: HTML retain links"
 else
     echo "FAIL: HTML retain links"
 fi
 
-./build/tablator --output-format=postgres test/multi.tbl - | diff -w - test/multi.postgres
+${tablator_bin} --output-format=postgres test/multi.tbl - | diff -w - test/multi.postgres
 if [ $? -eq 0 ]; then
     echo "PASS: Postgres output"
 else
     echo "FAIL: Postgres output"
 fi
 
-./build/tablator --output-format=oracle test/multi.tbl - | diff -w - test/multi.oracle
+${tablator_bin} --output-format=oracle test/multi.tbl - | diff -w - test/multi.oracle
 if [ $? -eq 0 ]; then
     echo "PASS: Oracle output"
 else
     echo "FAIL: Oracle output"
 fi
 
-./build/tablator --output-format=sqlite test/multi.tbl - | diff -w - test/multi.sqlite
+${tablator_bin} --output-format=sqlite test/multi.tbl - | diff -w - test/multi.sqlite
 if [ $? -eq 0 ]; then
     echo "PASS: SQLite output"
 else
     echo "FAIL: SQLite output"
 fi
 
-./build/tablator --output-format=csv test/multi.tbl - | diff -w - test/multi.csv
+${tablator_bin} --output-format=csv test/multi.tbl - | diff -w - test/multi.csv
 if [ $? -eq 0 ]; then
     echo "PASS: CSV output"
 else
     echo "FAIL: CSV output"
 fi
 
-./build/tablator --output-format=text test/empty_ipac_table - 2> /dev/null
+${tablator_bin} --output-format=text test/empty_ipac_table - 2> /dev/null
 if [ $? -eq 0 ]; then
     echo "FAIL: Empty IPAC Table"
 else
     echo "PASS: Empty IPAC Table"
 fi
 
-./build/tablator --output-format=text --input-format=csv test/empty - 2> /dev/null
+${tablator_bin} --output-format=text --input-format=csv test/empty - 2> /dev/null
 if [ $? -eq 0 ]; then
     echo "FAIL: Empty IPAC Table"
 else
     echo "PASS: Empty IPAC Table"
 fi
 
-./build/tablator --output-format=text --input-format=votable test/empty_votable - 2> /dev/null
+${tablator_bin} --output-format=text --input-format=votable test/empty_votable - 2> /dev/null
 if [ $? -eq 0 ]; then
     echo "FAIL: Empty VOTable"
 else
     echo "PASS: Empty VOTable"
 fi
 
-cat test/multi.csv | ./build/tablator --input-format=csv --output-format=csv - - | diff -w - test/multi.csv
+cat test/multi.csv | ${tablator_bin} --input-format=csv --output-format=csv - - | diff -w - test/multi.csv
 if [ $? -eq 0 ]; then
     echo "PASS: Read CSV From STDIN"
 else
     echo "FAIL: Read CSV From STDIN"
 fi
 
-./build/tablator --input-format=tsv --output-format=text test/no_trailing_newline.tsv - > /dev/null
+${tablator_bin} --input-format=tsv --output-format=text test/no_trailing_newline.tsv - > /dev/null
 if [ $? -eq 0 ]; then
     echo "PASS: Read TSV with no trailing newline"
 else
     echo "FAIL: Read TSV with no trailing newline"
+fi
+
+
+# JTODO: INFO section still does not survive the round trip.
+${tablator_bin} --output-format=fits  test/back_and_forth_tables/one_row_int_array.json5 - | ${tablator_bin} --input-format=fits - temp.json5 && diff -w  test/back_and_forth_tables/one_row_int_array.json5 temp.json5
+if [ $? -eq 0 ]; then
+    echo "PASS: Convert Json5 Table with single one-row array col of type int to FITS and back"
+    rm -f temp.json5
+else
+    echo "FAIL: Convert Json5 Table with single one-row array col of type int to FITS and back"
+fi
+
+# JTODO: INFO section still does not survive the round trip.
+${tablator_bin} --output-format=fits  test/back_and_forth_tables/two_row_int_array.json5 - | ${tablator_bin} --input-format=fits - temp.json5 && diff -w  test/back_and_forth_tables/two_row_int_array.json5 temp.json5
+if [ $? -eq 0 ]; then
+    echo "PASS: Convert Json5 Table with single two-row array col of type int to FITS and back"
+    rm -f temp.json5
+else
+    echo "FAIL: Convert Json5 Table with single two-row array col of type int to FITS and back"
+fi
+
+# JTODO: INFO section still does not survive the round trip.
+${tablator_bin} --output-format=fits  test/back_and_forth_tables/one_row_uint_array.json5 - | ${tablator_bin} --input-format=fits - temp.json5 && diff -w  test/back_and_forth_tables/one_row_uint_array.json5 temp.json5
+if [ $? -eq 0 ]; then
+    echo "PASS: Convert Json5 Table with single one-row array col of type uint to FITS and back"
+    rm -f temp.json5
+else
+    echo "FAIL: Convert Json5 Table with single one-row array col of type uint to FITS and back"
+fi
+
+# JTODO: INFO section still does not survive the round trip.
+${tablator_bin} --output-format=fits  test/back_and_forth_tables/two_row_uint_array.json5 - | ${tablator_bin} --input-format=fits - temp.json5 && diff -w  test/back_and_forth_tables/two_row_uint_array.json5 temp.json5
+if [ $? -eq 0 ]; then
+    echo "PASS: Convert Json5 Table with single two-row array col of type uint to FITS and back"
+    rm -f temp.json5
+else
+    echo "FAIL: Convert Json5 Table with single two-row array col of type uint to FITS and back"
+fi
+
+${tablator_bin} --output-format=fits  test/back_and_forth_tables/two_row_long_array.json5 - | ${tablator_bin} --input-format=fits - temp.json5 && diff -w  test/back_and_forth_tables/two_row_long_array.json5 temp.json5
+if [ $? -eq 0 ]; then
+    echo "PASS: Convert Json5 Table with single two-row array col of type long to FITS and back"
+    rm -f temp.json5
+else
+    echo "FAIL: Convert Json5 Table with single two-row array col of type long to FITS and back"
+fi
+
+${tablator_bin} --output-format=fits  test/back_and_forth_tables/two_row_ulong_array.json5 - | ${tablator_bin} --input-format=fits - temp.json5 && diff -w  test/back_and_forth_tables/two_row_ulong_array_via_fits.json5 temp.json5
+if [ $? -eq 0 ]; then
+    echo "PASS: Convert Json5 Table with single two-row array col of type ulong to FITS and back"
+    rm -f temp.json5
+else
+    echo "FAIL: Convert Json5 Table with single two-row array col of type ulong to FITS and back"
+fi
+
+
+${tablator_bin} --output-format=fits  test/back_and_forth_tables/one_row_bool_array.json5 - | ${tablator_bin} --input-format=fits - temp.json5 && diff -w  test/back_and_forth_tables/one_row_bool_array.json5 temp.json5
+if [ $? -eq 0 ]; then
+    echo "PASS: Convert Json5 Table with single one-row array col of type bool to FITS and back"
+    rm -f temp.json5
+else
+    echo "FAIL: Convert Json5 Table with single one-row array col of type bool to FITS and back"
+fi
+
+${tablator_bin} --output-format=fits  test/back_and_forth_tables/two_row_bool_array.json5 - | ${tablator_bin} --input-format=fits - temp.json5 && diff -w  test/back_and_forth_tables/two_row_bool_array.json5 temp.json5
+if [ $? -eq 0 ]; then
+    echo "PASS: Convert Json5 Table with single two-row array col of type bool to FITS and back"
+    rm -f temp.json5
+else
+    echo "FAIL: Convert Json5 Table with single two-row array col of type bool to FITS and back"
+fi
+
+${tablator_bin} --output-format=fits  test/back_and_forth_tables/single_bool_col.json5 - | ${tablator_bin} --input-format=fits - temp.json5 && diff -w  test/back_and_forth_tables/single_bool_col.json5 temp.json5
+if [ $? -eq 0 ]; then
+    echo "PASS: Convert Json5 Table with single multi-row non-array col of type bool to FITS and back"
+    rm -f temp.json5
+else
+    echo "FAIL: Convert Json5 Table with single multi-row non-array col of type bool to FITS and back"
 fi

--- a/test/recursive_param.xml
+++ b/test/recursive_param.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<VOTABLE version="1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:stc="http://www.ivoa.net/xml/STC/v1.30">
+<VOTABLE version="1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:stc="http://www.ivoa.net/xml/STC/v1.30" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/STC/v1.30 http://www.ivoa.net/xml/STC/v1.30">
   <RESOURCE>
     <PARAM name="INPUT:POS" datatype="char" arraysize="*" value="0,0">
       <DESCRIPTION>Search region center in the form</DESCRIPTION>

--- a/test/recursive_param_binary2.xml
+++ b/test/recursive_param_binary2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<VOTABLE version="1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:stc="http://www.ivoa.net/xml/STC/v1.30">
+<VOTABLE version="1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ivoa.net/xml/VOTable/v1.3" xmlns:stc="http://www.ivoa.net/xml/STC/v1.30" xsi:schemaLocation="http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/VOTable/v1.3 http://www.ivoa.net/xml/STC/v1.30 http://www.ivoa.net/xml/STC/v1.30">
   <RESOURCE>
     <PARAM name="INPUT:POS" datatype="char" arraysize="*" value="0,0">
       <DESCRIPTION>Search region center in the form</DESCRIPTION>


### PR DESCRIPTION
Hi, Serge.  I found I was able to cause translation errors and/or seg faults quite easily when converting tables with array-valued columns from json5 format to FITS and back again.  Values in int and uint columns were being written as 64-bit (thanks to the mysterious 'J' and 'V' fits_type options) but read as 32-bit.  The best fix might depend on how the translation functions are actually used. 

I also found translation errors, though not seg faults, with array-valued boolean columns.  This problem was caused by obvious careless errors in the relevant loops in read_fits().  

I added test cases to test/convert.sh and also gave that script a [-b path_to_tablator_binary] option to make it easier to compare the results of the script for different versions of the binary.

Thanks and I hope you feel better soon.  :-)