### PR TITLE
XML validation: Base arraysize attr value on column's array_size for …

### DIFF
--- a/test/back_and_forth_tables/integer_type_arrays.json5
+++ b/test/back_and_forth_tables/integer_type_arrays.json5
@@ -39,7 +39,7 @@
                             {
                                 "name": "big_uint64s",
                                 "datatype": "ulong",
-                                "arraysize": "*"
+                                "arraysize": "3"
                             }
                         },
                         {
@@ -47,7 +47,7 @@
                             {
                                 "name": "little_uint64s",
                                 "datatype": "ulong",
-                                "arraysize": "*"
+                                "arraysize": "5"
                             }
                         },
                         {
@@ -55,7 +55,7 @@
                             {
                                 "name": "any_uint32s",
                                 "datatype": "uint",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         }
                     ],

--- a/test/back_and_forth_tables/integer_type_arrays_from_json5.vot
+++ b/test/back_and_forth_tables/integer_type_arrays_from_json5.vot
@@ -11,8 +11,8 @@ little_uint64s (ulong)
 any_uint32s (uint)
 ___ array of uint32s</DESCRIPTION>
       <FIELD name="big_uint64s" datatype="char" arraysize="*"/>
-      <FIELD name="little_uint64s" datatype="long" arraysize="*"/>
-      <FIELD name="any_uint32s" datatype="long" arraysize="*"/>
+      <FIELD name="little_uint64s" datatype="long" arraysize="5"/>
+      <FIELD name="any_uint32s" datatype="long" arraysize="4"/>
       <DATA>
         <TABLEDATA>
           <TR>

--- a/test/back_and_forth_tables/multiple_info_example.vot
+++ b/test/back_and_forth_tables/multiple_info_example.vot
@@ -102,22 +102,22 @@ is returned (rather than all images containing the center).</DESCRIPTION>
       <FIELD name="sia_dec" datatype="double" ucd="POS_EQ_DEC_MAIN" unit="deg">
         <DESCRIPTION>ICRS declination of the image center.</DESCRIPTION>
       </FIELD>
-      <FIELD name="sia_naxis" datatype="int" arraysize="*" ucd="VOX:Image_Naxis">
+      <FIELD name="sia_naxis" datatype="int" arraysize="2" ucd="VOX:Image_Naxis">
         <DESCRIPTION>The image size in pixels along each axis</DESCRIPTION>
       </FIELD>
-      <FIELD name="sia_crpix" datatype="double" arraysize="*" ucd="VOX:WCS_CoordRefPixel" unit="pix">
+      <FIELD name="sia_crpix" datatype="double" arraysize="2" ucd="VOX:WCS_CoordRefPixel" unit="pix">
         <DESCRIPTION>Image pixel coordinates of the WCS reference pixel.</DESCRIPTION>
       </FIELD>
-      <FIELD name="sia_crval" datatype="double" arraysize="*" ucd="VOX:WCS_CoordRefValue" unit="deg">
+      <FIELD name="sia_crval" datatype="double" arraysize="2" ucd="VOX:WCS_CoordRefValue" unit="deg">
         <DESCRIPTION>World coordinates of the WCS reference pixel.</DESCRIPTION>
       </FIELD>
       <FIELD name="sia_proj" datatype="char" arraysize="*" ucd="VOX:WCS_CoordProjection">
         <DESCRIPTION>three character celestial projection code</DESCRIPTION>
       </FIELD>
-      <FIELD name="sia_scale" datatype="double" arraysize="*" ucd="VOX:Image_Scale" unit="deg/pix">
+      <FIELD name="sia_scale" datatype="double" arraysize="2" ucd="VOX:Image_Scale" unit="deg/pix">
         <DESCRIPTION>The scale of each image axis in degrees per pixel</DESCRIPTION>
       </FIELD>
-      <FIELD name="sia_cd" datatype="double" arraysize="*" ucd="VOX:WCS_CDMatrix" unit="deg/pix">
+      <FIELD name="sia_cd" datatype="double" arraysize="4" ucd="VOX:WCS_CDMatrix" unit="deg/pix">
         <DESCRIPTION>WCS CD matrix.</DESCRIPTION>
       </FIELD>
       <FIELD name="sia_bp_id" datatype="char" arraysize="*" ucd="VOX:BandPass_ID">

--- a/test/back_and_forth_tables/multiple_info_example_rearranged.vot
+++ b/test/back_and_forth_tables/multiple_info_example_rearranged.vot
@@ -113,22 +113,22 @@ is returned (rather than all images containing the center).</DESCRIPTION>
       <FIELD name="sia_dec" datatype="double" ucd="POS_EQ_DEC_MAIN" unit="deg">
         <DESCRIPTION>ICRS declination of the image center.</DESCRIPTION>
       </FIELD>
-      <FIELD name="sia_naxis" datatype="int" arraysize="*" ucd="VOX:Image_Naxis">
+      <FIELD name="sia_naxis" datatype="int" arraysize="2" ucd="VOX:Image_Naxis">
         <DESCRIPTION>The image size in pixels along each axis</DESCRIPTION>
       </FIELD>
-      <FIELD name="sia_crpix" datatype="double" arraysize="*" ucd="VOX:WCS_CoordRefPixel" unit="pix">
+      <FIELD name="sia_crpix" datatype="double" arraysize="2" ucd="VOX:WCS_CoordRefPixel" unit="pix">
         <DESCRIPTION>Image pixel coordinates of the WCS reference pixel.</DESCRIPTION>
       </FIELD>
-      <FIELD name="sia_crval" datatype="double" arraysize="*" ucd="VOX:WCS_CoordRefValue" unit="deg">
+      <FIELD name="sia_crval" datatype="double" arraysize="2" ucd="VOX:WCS_CoordRefValue" unit="deg">
         <DESCRIPTION>World coordinates of the WCS reference pixel.</DESCRIPTION>
       </FIELD>
       <FIELD name="sia_proj" datatype="char" arraysize="*" ucd="VOX:WCS_CoordProjection">
         <DESCRIPTION>three character celestial projection code</DESCRIPTION>
       </FIELD>
-      <FIELD name="sia_scale" datatype="double" arraysize="*" ucd="VOX:Image_Scale" unit="deg/pix">
+      <FIELD name="sia_scale" datatype="double" arraysize="2" ucd="VOX:Image_Scale" unit="deg/pix">
         <DESCRIPTION>The scale of each image axis in degrees per pixel</DESCRIPTION>
       </FIELD>
-      <FIELD name="sia_cd" datatype="double" arraysize="*" ucd="VOX:WCS_CDMatrix" unit="deg/pix">
+      <FIELD name="sia_cd" datatype="double" arraysize="4" ucd="VOX:WCS_CDMatrix" unit="deg/pix">
         <DESCRIPTION>WCS CD matrix.</DESCRIPTION>
       </FIELD>
       <FIELD name="sia_bp_id" datatype="char" arraysize="*" ucd="VOX:BandPass_ID">

--- a/test/back_and_forth_tables/multiple_resource_results_first.vot
+++ b/test/back_and_forth_tables/multiple_resource_results_first.vot
@@ -101,22 +101,22 @@ is returned (rather than all images containing the center).</DESCRIPTION>
       <FIELD name="sia_dec" datatype="double" ucd="POS_EQ_DEC_MAIN" unit="deg">
         <DESCRIPTION>ICRS declination of the image center.</DESCRIPTION>
       </FIELD>
-      <FIELD name="sia_naxis" datatype="int" arraysize="*" ucd="VOX:Image_Naxis">
+      <FIELD name="sia_naxis" datatype="int" arraysize="2" ucd="VOX:Image_Naxis">
         <DESCRIPTION>The image size in pixels along each axis</DESCRIPTION>
       </FIELD>
-      <FIELD name="sia_crpix" datatype="double" arraysize="*" ucd="VOX:WCS_CoordRefPixel" unit="pix">
+      <FIELD name="sia_crpix" datatype="double" arraysize="2" ucd="VOX:WCS_CoordRefPixel" unit="pix">
         <DESCRIPTION>Image pixel coordinates of the WCS reference pixel.</DESCRIPTION>
       </FIELD>
-      <FIELD name="sia_crval" datatype="double" arraysize="*" ucd="VOX:WCS_CoordRefValue" unit="deg">
+      <FIELD name="sia_crval" datatype="double" arraysize="2" ucd="VOX:WCS_CoordRefValue" unit="deg">
         <DESCRIPTION>World coordinates of the WCS reference pixel.</DESCRIPTION>
       </FIELD>
       <FIELD name="sia_proj" datatype="char" arraysize="*" ucd="VOX:WCS_CoordProjection">
         <DESCRIPTION>three character celestial projection code</DESCRIPTION>
       </FIELD>
-      <FIELD name="sia_scale" datatype="double" arraysize="*" ucd="VOX:Image_Scale" unit="deg/pix">
+      <FIELD name="sia_scale" datatype="double" arraysize="2" ucd="VOX:Image_Scale" unit="deg/pix">
         <DESCRIPTION>The scale of each image axis in degrees per pixel</DESCRIPTION>
       </FIELD>
-      <FIELD name="sia_cd" datatype="double" arraysize="*" ucd="VOX:WCS_CDMatrix" unit="deg/pix">
+      <FIELD name="sia_cd" datatype="double" arraysize="4" ucd="VOX:WCS_CDMatrix" unit="deg/pix">
         <DESCRIPTION>WCS CD matrix.</DESCRIPTION>
       </FIELD>
       <FIELD name="sia_bp_id" datatype="char" arraysize="*" ucd="VOX:BandPass_ID">

--- a/test/back_and_forth_tables/multiple_resource_results_first_rearranged.vot
+++ b/test/back_and_forth_tables/multiple_resource_results_first_rearranged.vot
@@ -112,22 +112,22 @@ is returned (rather than all images containing the center).</DESCRIPTION>
       <FIELD name="sia_dec" datatype="double" ucd="POS_EQ_DEC_MAIN" unit="deg">
         <DESCRIPTION>ICRS declination of the image center.</DESCRIPTION>
       </FIELD>
-      <FIELD name="sia_naxis" datatype="int" arraysize="*" ucd="VOX:Image_Naxis">
+      <FIELD name="sia_naxis" datatype="int" arraysize="2" ucd="VOX:Image_Naxis">
         <DESCRIPTION>The image size in pixels along each axis</DESCRIPTION>
       </FIELD>
-      <FIELD name="sia_crpix" datatype="double" arraysize="*" ucd="VOX:WCS_CoordRefPixel" unit="pix">
+      <FIELD name="sia_crpix" datatype="double" arraysize="2" ucd="VOX:WCS_CoordRefPixel" unit="pix">
         <DESCRIPTION>Image pixel coordinates of the WCS reference pixel.</DESCRIPTION>
       </FIELD>
-      <FIELD name="sia_crval" datatype="double" arraysize="*" ucd="VOX:WCS_CoordRefValue" unit="deg">
+      <FIELD name="sia_crval" datatype="double" arraysize="2" ucd="VOX:WCS_CoordRefValue" unit="deg">
         <DESCRIPTION>World coordinates of the WCS reference pixel.</DESCRIPTION>
       </FIELD>
       <FIELD name="sia_proj" datatype="char" arraysize="*" ucd="VOX:WCS_CoordProjection">
         <DESCRIPTION>three character celestial projection code</DESCRIPTION>
       </FIELD>
-      <FIELD name="sia_scale" datatype="double" arraysize="*" ucd="VOX:Image_Scale" unit="deg/pix">
+      <FIELD name="sia_scale" datatype="double" arraysize="2" ucd="VOX:Image_Scale" unit="deg/pix">
         <DESCRIPTION>The scale of each image axis in degrees per pixel</DESCRIPTION>
       </FIELD>
-      <FIELD name="sia_cd" datatype="double" arraysize="*" ucd="VOX:WCS_CDMatrix" unit="deg/pix">
+      <FIELD name="sia_cd" datatype="double" arraysize="4" ucd="VOX:WCS_CDMatrix" unit="deg/pix">
         <DESCRIPTION>WCS CD matrix.</DESCRIPTION>
       </FIELD>
       <FIELD name="sia_bp_id" datatype="char" arraysize="*" ucd="VOX:BandPass_ID">

--- a/test/back_and_forth_tables/one_row_bool_array.json5
+++ b/test/back_and_forth_tables/one_row_bool_array.json5
@@ -21,7 +21,7 @@
                             {
                                 "name": "bools",
                                 "datatype": "boolean",
-                                "arraysize": "*"
+                                "arraysize": "19"
                             }
                         }
                     ],

--- a/test/back_and_forth_tables/one_row_int_array.json5
+++ b/test/back_and_forth_tables/one_row_int_array.json5
@@ -37,7 +37,7 @@
                             {
                                 "name": "ints",
                                 "datatype": "int",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         }
                     ],

--- a/test/back_and_forth_tables/one_row_uint_array.json5
+++ b/test/back_and_forth_tables/one_row_uint_array.json5
@@ -21,7 +21,7 @@
                             {
                                 "name": "uints",
                                 "datatype": "uint",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         }
                     ],

--- a/test/back_and_forth_tables/partial_euclid.vot
+++ b/test/back_and_forth_tables/partial_euclid.vot
@@ -36,7 +36,7 @@
       <FIELD name="blended_prob" datatype="float"/>
       <FIELD name="concentration" datatype="float"/>
       <FIELD name="concentration_err" datatype="float"/>
-      <FIELD name="deblended_companions" datatype="long" arraysize="*"/>
+      <FIELD name="deblended_companions" datatype="long" arraysize="5"/>
       <FIELD name="deblended_flag" datatype="int"/>
       <FIELD name="declination" datatype="double"/>
       <FIELD name="det_quality_flag" datatype="int"/>

--- a/test/back_and_forth_tables/small_fits_unsupported_integer_type_arrays.json5
+++ b/test/back_and_forth_tables/small_fits_unsupported_integer_type_arrays.json5
@@ -20,7 +20,7 @@
                         {
                             "name": "bools",
                             "datatype": "boolean",
-                            "arraysize": "*"
+                            "arraysize": "4"
                         }
                     },
                     {
@@ -28,7 +28,7 @@
                         {
                             "name": "ubools",
                             "datatype": "unsignedByte",
-                            "arraysize": "*"
+                            "arraysize": "4"
                         }
                     },
                     {
@@ -36,7 +36,7 @@
                         {
                             "name": "small_shorts",
                             "datatype": "short",
-                            "arraysize": "*"
+                            "arraysize": "4"
                         }
                     },
                     {
@@ -44,7 +44,7 @@
                         {
                             "name": "small_ushorts",
                             "datatype": "ushort",
-                            "arraysize": "*"
+                            "arraysize": "4"
                         }
                     },
                     {
@@ -52,7 +52,7 @@
                         {
                             "name": "small_int32s",
                             "datatype": "int",
-                            "arraysize": "*"
+                            "arraysize": "4"
                         }
                     },
                     {
@@ -60,7 +60,7 @@
                         {
                             "name": "small_uint32s",
                             "datatype": "uint",
-                            "arraysize": "*"
+                            "arraysize": "4"
                         }
                     },
                     {
@@ -68,7 +68,7 @@
                         {
                             "name": "small_longs",
                             "datatype": "long",
-                            "arraysize": "*"
+                            "arraysize": "4"
                         }
                     },
                     {
@@ -76,7 +76,7 @@
                         {
                             "name": "small_ulongs",
                             "datatype": "ulong",
-                            "arraysize": "*"
+                            "arraysize": "4"
                         }
                     }
                 ],

--- a/test/back_and_forth_tables/small_fits_unsupported_integer_type_arrays_via_fits.json5
+++ b/test/back_and_forth_tables/small_fits_unsupported_integer_type_arrays_via_fits.json5
@@ -21,7 +21,7 @@
                             {
                                 "name": "bools",
                                 "datatype": "boolean",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         },
                         {
@@ -29,7 +29,7 @@
                             {
                                 "name": "ubools",
                                 "datatype": "unsignedByte",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         },
                         {
@@ -37,7 +37,7 @@
                             {
                                 "name": "small_shorts",
                                 "datatype": "short",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         },
                         {
@@ -45,7 +45,7 @@
                             {
                                 "name": "small_ushorts",
                                 "datatype": "ushort",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         },
                         {
@@ -53,7 +53,7 @@
                             {
                                 "name": "small_int32s",
                                 "datatype": "int",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         },
                         {
@@ -61,7 +61,7 @@
                             {
                                 "name": "small_uint32s",
                                 "datatype": "uint",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         },
                         {
@@ -69,7 +69,7 @@
                             {
                                 "name": "small_longs",
                                 "datatype": "long",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         },
                         {
@@ -77,7 +77,7 @@
                             {
                                 "name": "small_ulongs",
                                 "datatype": "long",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         }
                     ],

--- a/test/back_and_forth_tables/small_integer_type_arrays.json5
+++ b/test/back_and_forth_tables/small_integer_type_arrays.json5
@@ -38,7 +38,7 @@
                             {
                                 "name": "bools",
                                 "datatype": "boolean",
-                                "arraysize": "*"
+                                "arraysize": "19"
                             }
                         },
                         {
@@ -46,7 +46,7 @@
                             {
                                 "name": "ubools",
                                 "datatype": "unsignedByte",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         },
                         {
@@ -54,7 +54,7 @@
                             {
                                 "name": "small_shorts",
                                 "datatype": "short",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         },
                         {
@@ -62,7 +62,7 @@
                             {
                                 "name": "small_ushorts",
                                 "datatype": "ushort",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         },
                         {
@@ -70,7 +70,7 @@
                             {
                                 "name": "small_int32s",
                                 "datatype": "int",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         },
                         {
@@ -78,7 +78,7 @@
                             {
                                 "name": "small_uint32s",
                                 "datatype": "uint",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         },
                         {
@@ -86,7 +86,7 @@
                             {
                                 "name": "small_longs",
                                 "datatype": "long",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         },
                         {
@@ -94,7 +94,7 @@
                             {
                                 "name": "small_ulongs",
                                 "datatype": "long",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         }
                     ],

--- a/test/back_and_forth_tables/two_row_bool_array.json5
+++ b/test/back_and_forth_tables/two_row_bool_array.json5
@@ -21,7 +21,7 @@
                             {
                                 "name": "bools",
                                 "datatype": "boolean",
-                                "arraysize": "*"
+                                "arraysize": "19"
                             }
                         }
                     ],

--- a/test/back_and_forth_tables/two_row_byte_array.json5
+++ b/test/back_and_forth_tables/two_row_byte_array.json5
@@ -21,7 +21,7 @@
                             {
                                 "name": "bytes",
                                 "datatype": "unsignedByte",
-                                "arraysize": "*"
+                                "arraysize": "8"
                             }
                         }
                     ],

--- a/test/back_and_forth_tables/two_row_int_array.json5
+++ b/test/back_and_forth_tables/two_row_int_array.json5
@@ -38,7 +38,7 @@
                             {
                                 "name": "ints",
                                 "datatype": "int",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         }
                     ],

--- a/test/back_and_forth_tables/two_row_long_array.json5
+++ b/test/back_and_forth_tables/two_row_long_array.json5
@@ -21,7 +21,7 @@
                             {
                                 "name": "longs",
                                 "datatype": "long",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         }
                     ],

--- a/test/back_and_forth_tables/two_row_uint_array.json5
+++ b/test/back_and_forth_tables/two_row_uint_array.json5
@@ -38,7 +38,7 @@
                             {
                                 "name": "uints",
                                 "datatype": "uint",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         }
                     ],

--- a/test/back_and_forth_tables/two_row_ulong_array.json5
+++ b/test/back_and_forth_tables/two_row_ulong_array.json5
@@ -21,7 +21,7 @@
                             {
                                 "name": "ulong1",
                                 "datatype": "ulong",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         }
                     ],

--- a/test/back_and_forth_tables/two_row_ulong_array_via_fits.json5
+++ b/test/back_and_forth_tables/two_row_ulong_array_via_fits.json5
@@ -21,7 +21,7 @@
                             {
                                 "name": "ulong1",
                                 "datatype": "long",
-                                "arraysize": "*"
+                                "arraysize": "4"
                             }
                         }
                     ],

--- a/test/convert.sh
+++ b/test/convert.sh
@@ -338,7 +338,7 @@ else
     echo "FAIL: Convert Json5 Table with large uint64 vals array col to VOTable"
 fi
 
-# JTODO: datatypes and array_sizes do not survive the round trip via votable.
+# JTODO: datatypes do not survive the round trip via votable.
 ${tablator_bin} --input-format=json5 --output-format=votable test/back_and_forth_tables/integer_type_arrays.json5 temp.vot && diff -w test/back_and_forth_tables/integer_type_arrays_from_json5.vot temp.vot
 if [ $? -eq 0 ]; then
     echo "PASS: Convert Json5 Table with assorted array cols to VOTable"


### PR DESCRIPTION
…non-char columns

Previously the arraysize attr value was set to '*' whenever column.array_size != 1.