### PR TITLE
IRSA-6967: tablator: store row-level size of variable-length arrays I

### DIFF
--- a/src/Column.hxx
+++ b/src/Column.hxx
@@ -24,9 +24,19 @@ public:
 
     Column(const std::string &name, const Data_Type &type, const size_t &array_size,
            const Field_Properties &field_properties)
-            : Column(name, type, array_size, field_properties,
-                     ((type == Data_Type::CHAR) ||
-                      (array_size == std::numeric_limits<size_t>::max()))) {}
+            : Column(name, type, array_size, field_properties, [&]() {
+                  if (type == Data_Type::CHAR) {
+                      return true;
+                  }
+                  if (array_size == std::numeric_limits<size_t>::max()) {
+                      return true;
+                  }
+                  const auto iter = field_properties.get_attributes().find("arraysize");
+                  if (iter != field_properties.get_attributes().end()) {
+                      return (iter->second == "*");
+                  }
+                  return false;
+              }()) {}
 
     Column(const std::string &name, const Data_Type &type, const size_t &array_size,
            bool dynamic_array_flag)

--- a/src/Data_Details.hxx
+++ b/src/Data_Details.hxx
@@ -17,7 +17,6 @@ public:
 
     void append_row(const Row &row) {
         assert(row.get_data().size() == get_row_size());
-        data_.reserve(data_.size() + row.get_data().size());
         data_.insert(data_.end(), row.get_data().begin(), row.get_data().end());
     }
 

--- a/src/Data_Element.hxx
+++ b/src/Data_Element.hxx
@@ -10,7 +10,8 @@ class Data_Element {
 public:
     Data_Element(const Field_Framework &field_framework,
                  const Data_Details &data_details)
-            : field_framework_(field_framework), data_details_(data_details) {}
+            : field_framework_(std::move(field_framework)),
+              data_details_(std::move(data_details)) {}
 
     Data_Element(const Field_Framework &field_framework, size_t num_rows = 0)
             : Data_Element(field_framework, Data_Details(field_framework, num_rows)) {}

--- a/src/Resource_Element.hxx
+++ b/src/Resource_Element.hxx
@@ -163,7 +163,7 @@ private:
         }
 
         void add_table_element(const Table_Element &table_element) {
-            table_elements_.emplace_back(table_element);
+            table_elements_.emplace_back(std::move(table_element));
         }
 
         void add_trailing_info_list(const std::vector<Property> &trailing_info_list) {
@@ -183,11 +183,11 @@ public:
         Builder() {}
 
         Builder(const std::vector<Table_Element> &table_elements) {
-            options_.table_elements_ = table_elements;
+            options_.table_elements_ = std::move(table_elements);
         }
 
         Builder(const Table_Element &table_element) {
-            options_.table_elements_.emplace_back(table_element);
+            options_.table_elements_.emplace_back(std::move(table_element));
         }
 
         Resource_Element build() { return Resource_Element(options_); }
@@ -284,7 +284,7 @@ public:
     Resource_Element(const Table_Element &table_element)
             : resource_type_(Resource_Type::RESULTS) {
         assert(!table_element.get_columns().empty());
-        get_table_elements().emplace_back(table_element);
+        get_table_elements().emplace_back(std::move(table_element));
     }
 
     Resource_Element() : resource_type_(Resource_Type::META) {}
@@ -466,7 +466,7 @@ public:
 
 private:
     Resource_Element(const Options &options)
-            : options_(options),
+            : options_(std::move(options)),
               resource_type_(determine_resource_type(options_.table_elements_,
                                                      options_.attributes_)) {}
     Options options_;

--- a/src/Table.hxx
+++ b/src/Table.hxx
@@ -129,7 +129,7 @@ public:
     public:
         // JTODO check that resource_elements contains at least one Table_Element?
         Builder(std::vector<Resource_Element> &resource_elements)
-                : resource_elements_(resource_elements) {}
+                : resource_elements_(std::move(resource_elements)) {}
 
         Table build() { return Table(resource_elements_, options_); }
 
@@ -201,6 +201,7 @@ public:
     Table(const std::vector<Column> &Columns,
           const tablator::Labeled_Properties &property_pair_vec,
           bool got_null_bitfields_column = false, size_t num_rows = 0);
+
     Table(const std::vector<Column> &Columns, bool got_null_bitfields_column = false,
           size_t num_rows = 0)
             : Table(Columns, std::map<std::string, std::string>(),
@@ -856,7 +857,7 @@ public:
     }
 
     void add_resource_element(const Resource_Element &resource_element) {
-        resource_elements_.emplace_back(resource_element);
+        resource_elements_.emplace_back(std::move(resource_element));
         arrange_resources();
     }
 
@@ -1026,7 +1027,8 @@ private:
 
     Table(const std::vector<Resource_Element> &resource_elements,
           const Options &options)
-            : resource_elements_(resource_elements), options_(options) {
+            : resource_elements_(std::move(resource_elements)),
+              options_(std::move(options)) {
         arrange_resources();
     }
 

--- a/src/Table/Column_Row_Accessors.cxx
+++ b/src/Table/Column_Row_Accessors.cxx
@@ -90,8 +90,8 @@ void validate_parameters(const tablator::Row &row, const tablator::Table &table,
     }
     if (row.get_size() != table.get_row_size()) {
         std::stringstream msg_ss;
-        msg_ss << "Invalid col_idx: " << std::to_string(col_idx)
-               << ", num_columns: " << table_columns.size();
+        msg_ss << "Invalid row size: " << row.get_size()
+               << ", table row size: " << table.get_row_size();
         ;
         throw std::runtime_error(msg_ss.str());
     }
@@ -114,8 +114,8 @@ void insert_blob_to_row_internal(tablator::Row &row, const tablator::Table &tabl
                                  const uint8_t *data_ptr,
                                  uint32_t num_elements_to_insert) {
     const auto &column = table.get_columns().at(col_idx);
-    auto data_size = tablator::data_size(column.get_type());
-    auto insert_offset = table.get_offsets().at(col_idx) + elt_idx * data_size;
+    const auto data_size = tablator::data_size(column.get_type());
+    const auto insert_offset = table.get_offsets().at(col_idx) + elt_idx * data_size;
     row.insert(data_ptr, data_ptr + num_elements_to_insert * data_size, insert_offset);
 }
 }  // namespace

--- a/src/Table/Table.cxx
+++ b/src/Table/Table.cxx
@@ -57,14 +57,17 @@ namespace tablator {
 // Implementation of Table member functions
 // =========================================================
 
+// Constructors
+
 Table::Table(const std::vector<Column> &columns,
              const std::map<std::string, std::string> &property_map,
              bool got_null_bitfields_column, size_t num_rows) {
     add_resource_element(
-            Table_Element::Builder(Field_Framework(columns, got_null_bitfields_column),
-                                   num_rows)
+            Table_Element::Builder(Field_Framework(columns, got_null_bitfields_column))
                     .build());
-
+    // Call reserve() after constructing Table_Element as std::move()
+    // does not necessarily preserve capacity.
+    reserve_rows(num_rows);
     for (auto &p : property_map) {
         add_labeled_property(p.first, Property(p.second));
     }
@@ -76,10 +79,9 @@ Table::Table(const std::vector<Column> &columns,
              bool got_null_bitfields_column, size_t num_rows)
         : results_resource_idx_(0) {
     add_resource_element(
-            Table_Element::Builder(Field_Framework(columns, got_null_bitfields_column),
-                                   num_rows)
+            Table_Element::Builder(Field_Framework(columns, got_null_bitfields_column))
                     .build());
-
+    reserve_rows(num_rows);
     for (const auto &label_and_prop : property_pair_vec) {
         if (boost::starts_with(label_and_prop.first, VOTABLE_RESOURCE_DOT)) {
             add_resource_element_labeled_property(

--- a/src/Table/generate_property_tree/add_to_property_tree.cxx
+++ b/src/Table/generate_property_tree/add_to_property_tree.cxx
@@ -160,7 +160,9 @@ void add_to_property_tree(boost::property_tree::ptree &parent_tree,
 
     size_t col_array_size = column.get_array_size();
     bool early_arraysize_f = false;
-    if (active_datatype == Data_Type::CHAR) {
+
+    if ((active_datatype == Data_Type::CHAR && column.get_type() != Data_Type::CHAR) ||
+        column.get_dynamic_array_flag()) {
         field_tree.add(XMLATTR_ARRAYSIZE, "*");
         early_arraysize_f = true;
     } else if (col_array_size != 1) {

--- a/src/Table_Element.hxx
+++ b/src/Table_Element.hxx
@@ -90,24 +90,24 @@ public:
         Builder() {}
 
         Builder(const Data_Element &data_element) {
-            data_elements_.emplace_back(data_element);
+            data_elements_.emplace_back(std::move(data_element));
         }
 
         Builder(const std::vector<Data_Element> &data_elements)
-                : data_elements_(data_elements) {}
+                : data_elements_(std::move(data_elements)) {}
 
         Builder(const Field_Framework &field_framework,
                 const Data_Details &data_details) {
-            data_elements_.emplace_back(Data_Element(field_framework, data_details));
+            data_elements_.emplace_back(field_framework, data_details);
         }
 
         Builder(const Field_Framework &field_framework, size_t num_rows) {
-            data_elements_.emplace_back(Data_Element(field_framework, num_rows));
+            data_elements_.emplace_back(field_framework, num_rows);
         }
 
 
         Builder(const Field_Framework &field_framework) {
-            data_elements_.emplace_back(Data_Element(field_framework));
+            data_elements_.emplace_back(field_framework);
         }
 
         Table_Element build() { return Table_Element(data_elements_, options_); }
@@ -310,7 +310,7 @@ public:
 private:
     Table_Element(const std::vector<Data_Element> &data_elements,
                   const Options &options)
-            : data_elements_(data_elements), options_(options) {
+            : data_elements_(std::move(data_elements)), options_(std::move(options)) {
         // JTODO  What exactly is our restriction on Table_Elements?
         if (data_elements_.empty() || get_columns().empty()) {
             throw std::runtime_error("Table_Element must have non-empty Data_Element.");

--- a/test/convert.sh
+++ b/test/convert.sh
@@ -1414,7 +1414,7 @@ if [ $? -eq 0 ]; then
     echo "PASS: combine vot tables and write as tbl"
     rm -f temp.tbl
 else
-    echo "PASS: combine vot tables and write as tbl"
+    echo "FAIL: combine vot tables and write as tbl"
 fi
 
 


### PR DESCRIPTION
Column constructor: Now consider arraysize attribute when setting dynamic_array_flag_.

Performance enhancements:
   Assorted constructors: Now call std::move().
   Data_Details: Removed reserve() call from append_row();
      the call to insert() increases capacity more efficiently.